### PR TITLE
Fix advice when a record can't be found

### DIFF
--- a/app/views/v2/school/not-found.html
+++ b/app/views/v2/school/not-found.html
@@ -22,7 +22,7 @@ href: "javascript:window.history.back()"
             </p>
 
             <p class="govuk-body">
-                Alternatively, you can ask the ECT to check their TRN by using the <a href="https://find-a-lost-trn.education.gov.uk/start" class="govuk-link">find a lost TRN service</a>.
+                Alternatively, you can ask the ECT to check their TRN by using the <a href="https://find-a-lost-trn.education.gov.uk/start" class="govuk-link">Find a lost TRN service</a>.
             </p>
 
             <button class="govuk-button">Try again</button>


### PR DESCRIPTION
The info given was just relevant for mentors, not ECTs. ECTs should always have a TRN already in virtue of either training towards QTS or being awarded QTS. They shouldn't have to request a TRN.