### PR TITLE
Content updates

### DIFF
--- a/app/views/v3/school/check-answers.html
+++ b/app/views/v3/school/check-answers.html
@@ -143,7 +143,7 @@ href: "javascript:window.history.back()"
 
             {% set rows = rows.concat([{
             key: {
-            text: "Induction start"
+            text: "Start date"
             },
             value: {
             text: month | monthName + " " + year

--- a/app/views/v3/school/confirmation-mentor-to-be-added.html
+++ b/app/views/v3/school/confirmation-mentor-to-be-added.html
@@ -6,7 +6,7 @@
 {% set name = 'John Smith' %}
 {% endif %}
 
-{% set pageName="What you'll need to do next" %}
+{% set pageName="What you need to do next" %}
 
 {% block beforeContent %}
 {% endblock %}
@@ -16,11 +16,12 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
         <h1 class="govuk-heading-l">{{ pageName }}</h1>
-        <p>{{name}} has been added to your school as an early career teacher.</p>
+        <p>{{name}} has been added to your school as an ECT.</p>
         <p class="govuk-body">
-            To complete your ECT's registration you must assign them a mentor. Before you can do this, you must first add a mentor to your school, if you have not done so already.
+            To complete their registration you must assign them a mentor. 
         </p>
-
+        <p class="govuk-body">
+            <p>Before you can do this, you must first add a mentor to your school, if you have not done so already.</p>
         <a class="govuk-button" href="mentor/what-youll-need">Add a new mentor for {{name}}</a>
 
         <p><a href="home/ects">Back to your ECTs</a></p>

--- a/app/views/v3/school/home/ects.html
+++ b/app/views/v3/school/home/ects.html
@@ -3,9 +3,15 @@
 {% block head %}
 {{ super() }} <!-- This includes the content from the base head block -->
 {% include "./filters.njk" %}
+<style>
+    /* Custom style for larger font size */
+    .large-font {
+        font-size: 1.5rem; /* Adjust the size as needed */
+    }
+</style>
 {% endblock %}
 
-{% set pageName="Early career teachers (ECTs)" %}
+{% set pageName="Early career teachers" %}
 
 {% block content %}
 
@@ -13,7 +19,7 @@
     <div class="govuk-grid-column-full">
         <h1 class="govuk-caption-l">Test Primary School</h1>
         <h1 class="govuk-heading-l">{{pageName}}</h1>
-        <a href="../what-youll-need" class="govuk-button">Add an ECT</a>
+        <a href="../what-youll-need" class="govuk-button">Register a new ECT</a>
         <hr class="govuk-section-break--m">
     </div>
 
@@ -25,25 +31,6 @@
                         <label class="govuk-label govuk-label--m" for="keywords"> Search by name </label>
                         <input class="govuk-input" id="keywords" name="keywords" type="text">
                     </div>
-<!--                    <div class="govuk-form-group">-->
-<!--                        <fieldset class="govuk-fieldset">-->
-<!--                            <legend class="govuk-fieldset__legend govuk-fieldset__legend&#45;&#45;m"> Status </legend>-->
-<!--                            <div class="govuk-checkboxes govuk-checkboxes&#45;&#45;small" data-module="govuk-checkboxes">-->
-<!--                                <div class="govuk-checkboxes__item">-->
-<!--                                    <input class="govuk-checkboxes__input" id="status" name="status" type="checkbox" value="complete">-->
-<!--                                    <label class="govuk-label govuk-checkboxes__label" for="status"> Completed </label>-->
-<!--                                </div>-->
-<!--                                <div class="govuk-checkboxes__item">-->
-<!--                                    <input class="govuk-checkboxes__input" id="status-2" name="status" type="checkbox" value="withdrawn">-->
-<!--                                    <label class="govuk-label govuk-checkboxes__label" for="status-2"> Withdrawn </label>-->
-<!--                                </div>-->
-<!--                                <div class="govuk-checkboxes__item">-->
-<!--                                    <input class="govuk-checkboxes__input" id="status-3" name="status" type="checkbox" value="inprogress">-->
-<!--                                    <label class="govuk-label govuk-checkboxes__label" for="status-3"> In progress </label>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </fieldset>-->
-<!--                    </div>-->
                 </div>
             </div>
         </div>
@@ -55,24 +42,24 @@
 
         <div class="govuk-summary-card">
             <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title">
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-regular" href="#">John Smith</a>
-                </h2>
+                <h3 class="govuk-summary-card__title large-font">
+                    <strong><a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold" href="#">John Smith</a></strong>
+                </h3>
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Status</dt>
-                    <dd class="govuk-summary-list__value">
-                        <strong class="govuk-tag govuk-tag--red">Requires attention</strong>
-                    </dd>
-                </div>
+                        <dd class="govuk-summary-list__value">
+                            <strong class="govuk-tag govuk-tag--red">Mentor required</strong>
+                        </dd>
+                    </div>
                     {% if data['ectAddedWithoutMentor'] === 'yes' %}
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Mentor</dt>
-                        <dd class="govuk-summary-list__value govuk-inset-text">
-                                <p>No mentor assigned</p>
-                                <a class="govuk-link govuk-link--no-visited-state" href="../mentor/who-will-be-mentoring">Assign or add a new mentor</a>
+                        <dd class="govuk-summary-list__value">
+                    
+                                <a class="govuk-link govuk-link--no-visited-state" href="../mentor/who-will-be-mentoring">Assign a mentor or register a new one</a>       
                         </dd>
                     </div>
                     {% else %}
@@ -96,16 +83,16 @@
 
         <div class="govuk-summary-card">
             <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title">
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-regular" href="#">Steven Taylor</a>
-                </h2>
+                <h3 class="govuk-summary-card__title large-font">
+                    <strong><a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold" href="#">Steven Taylor</a></strong>
+                </h3>
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Status</dt>
                         <dd class="govuk-summary-list__value">
-                            <strong class="govuk-tag govuk-tag--green">In progress</strong>
+                            <strong class="govuk-tag govuk-tag--green">Registered</strong>
                         </dd>
                     </div>
                     <div class="govuk-summary-list__row">
@@ -117,18 +104,19 @@
                 </dl>
             </div>
         </div>
+
         <div class="govuk-summary-card">
             <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title">
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-regular" href="#">Emily Brown</a>
-                </h2>
+                <h3 class="govuk-summary-card__title large-font">
+                    <strong><a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold" href="#">Emily Brown</a></strong>
+                </h3>
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
                     <div class="govuk-summary-list__row">
                         <dt class="govuk-summary-list__key">Status</dt>
                         <dd class="govuk-summary-list__value">
-                            <strong class="govuk-tag govuk-tag--green">In progress</strong>
+                            <strong class="govuk-tag govuk-tag--green">Registered</strong>
                         </dd>
                     </div>
                     <div class="govuk-summary-list__row">
@@ -140,8 +128,6 @@
                 </dl>
             </div>
         </div>
-
-
 
     </div>
 </div>

--- a/app/views/v3/school/home/mentors.html
+++ b/app/views/v3/school/home/mentors.html
@@ -3,6 +3,12 @@
 {% block head %}
 {{ super() }} <!-- This includes the content from the base head block -->
 {% include "./filters.njk" %}
+<style>
+    /* Custom style for larger font size */
+    .large-font {
+        font-size: 1.5rem; /* Adjust the size as needed */
+    }
+</style>
 {% endblock %}
 
 {% set pageName="Mentors" %}
@@ -13,7 +19,6 @@
     <div class="govuk-grid-column-full">
         <h1 class="govuk-caption-l">Test Primary School</h1>
         <h1 class="govuk-heading-l">{{pageName}}</h1>
-<!--        <a href="#" class="govuk-button">Add a mentor</a>-->
         <hr class="govuk-section-break--m">
     </div>
 
@@ -25,25 +30,6 @@
                         <label class="govuk-label govuk-label--m" for="keywords"> Search by name </label>
                         <input class="govuk-input" id="keywords" name="keywords" type="text">
                     </div>
-<!--                    <div class="govuk-form-group">-->
-<!--                        <fieldset class="govuk-fieldset">-->
-<!--                            <legend class="govuk-fieldset__legend govuk-fieldset__legend&#45;&#45;m"> Status </legend>-->
-<!--                            <div class="govuk-checkboxes govuk-checkboxes&#45;&#45;small" data-module="govuk-checkboxes">-->
-<!--                                <div class="govuk-checkboxes__item">-->
-<!--                                    <input class="govuk-checkboxes__input" id="status" name="status" type="checkbox" value="complete">-->
-<!--                                    <label class="govuk-label govuk-checkboxes__label" for="status"> Completed </label>-->
-<!--                                </div>-->
-<!--                                <div class="govuk-checkboxes__item">-->
-<!--                                    <input class="govuk-checkboxes__input" id="status-2" name="status" type="checkbox" value="withdrawn">-->
-<!--                                    <label class="govuk-label govuk-checkboxes__label" for="status-2"> Withdrawn </label>-->
-<!--                                </div>-->
-<!--                                <div class="govuk-checkboxes__item">-->
-<!--                                    <input class="govuk-checkboxes__input" id="status-3" name="status" type="checkbox" value="inprogress">-->
-<!--                                    <label class="govuk-label govuk-checkboxes__label" for="status-3"> In progress </label>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </fieldset>-->
-<!--                    </div>-->
                 </div>
             </div>
         </div>
@@ -53,13 +39,13 @@
 
         <div class="govuk-summary-card">
             <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title">
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-regular" href="">John Doe</a></h2>
+                <h3 class="govuk-summary-card__title">
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold large-font" href="">John Doe</a></h3>
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">ECTs currently mentoring</dt>
+                        <dt class="govuk-summary-list__key">ECTs assigned to mentor</dt>
                         <dd class="govuk-summary-list__value">
                             <div class="app-summary-list__missing">
                                 <div class="app-summary-list__missing-heading">None</div>
@@ -69,15 +55,16 @@
                 </dl>
             </div>
         </div>
+        
         <div class="govuk-summary-card">
             <div class="govuk-summary-card__title-wrapper">
-                <h2 class="govuk-summary-card__title">
-                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-regular" href="">Tom Jones</a></h2>
+                <h3 class="govuk-summary-card__title">
+                    <a class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-bold large-font" href="">Tom Jones</a></h3>
             </div>
             <div class="govuk-summary-card__content">
                 <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
                     <div class="govuk-summary-list__row">
-                        <dt class="govuk-summary-list__key">ECTs currently mentoring</dt>
+                        <dt class="govuk-summary-list__key">ECTs assigned to mentor</dt>
                         <dd class="govuk-summary-list__value">
                             <div class="app-summary-list__missing">
                                 <div class="app-summary-list__missing-heading">None</div>

--- a/app/views/v3/school/mentor.html
+++ b/app/views/v3/school/mentor.html
@@ -32,6 +32,9 @@ href: "javascript:window.history.back()"
         classes: "govuk-fieldset__legend--l"
         }
         },
+        hint: {
+        text: "Choose from the list of mentors you've already registered at your school."
+        },
         items: [
         {
         value: "John Doe",

--- a/app/views/v3/school/mentor/check-answers.html
+++ b/app/views/v3/school/mentor/check-answers.html
@@ -43,13 +43,12 @@ href: "javascript:window.history.back()"
             {% set whoRows = [
             {
             key: {
-            text: "ECT being mentored"
+            text: "Who they will mentor"
             },
             value: {
             text: "John Smith"
             }
             }
-
             ] %}
 
             {% set rows = [
@@ -120,9 +119,25 @@ href: "javascript:window.history.back()"
             }
             ]
             }
+            },
+            {
+            key: {
+            text: "Who they will mentor"
+            },
+            value: {
+            text: "John Smith"
+            },
+            actions: {
+            items: [
+            {
+            href: "#",
+            text: "Change",
+            visuallyHiddenText: "Who they will mentor"
+            }
+            ]
+            }
             }
             ] %}
-
 
             {% if data['askForNino'] == 'yes' %}
             {% set rows = rows.concat([{
@@ -134,14 +149,6 @@ href: "javascript:window.history.back()"
             }
             }]) %}
             {% endif %}
-
-
-<!--            <h2 class="govuk-heading-m">Who they're mentoring</h2>-->
-
-<!--            {{ govukSummaryList({ rows: whoRows }) }}-->
-
-            <h2 class="govuk-heading-m">Who they're mentoring</h2>
-            {{ govukSummaryList({ rows: whoRows }) }}
 
             <h2 class="govuk-heading-m">Mentor details</h2>
 

--- a/app/views/v3/school/mentor/confirmation.html
+++ b/app/views/v3/school/mentor/confirmation.html
@@ -6,7 +6,7 @@
 {% set name = 'Samuel Taylor' %}
 {% endif %}
 
-{% set pageName="You have registered " + name + " as a mentor" %}
+{% set pageName="You've registered " + name + " as a mentor" %}
 
 {% block beforeContent %}
 {% endblock %}
@@ -20,12 +20,13 @@
                 {{ pageName }}
             </h1>
             <div class="govuk-panel__body">
-                For<br><strong>John Smith</strong>
+                for<br><strong>John Smith</strong>
             </div>
         </div>
         <h2 class="govuk-heading-m">What happens next</h2>
-        <p class="govuk-body">We’ll let this person know you’ve registered them for ECF-based mentoring at your school. They do not need to provide us with any more information.</p>
-
+        <p class="govuk-body">We’ll notify Samuel Taylor and John Smith that they are registered at your school.<p/p>
+        <p>Samuel Taylor is now John Smith’s mentor, and this completes John Smith’s registration as an ECT at your school.</p>
+        <p class="govuk-body"> They do not need to give us any more information.</p>
         <p><a href="#">Back to your ECTs</a></p>
     </div>
 </div>

--- a/app/views/v3/school/mentor/review-mentor-details.html
+++ b/app/views/v3/school/mentor/review-mentor-details.html
@@ -117,7 +117,9 @@ href: "javascript:window.history.back()"
             </button>
         </form>
 
-        <p>If this is not the person you intended to register as a mentor, go back and <a href="find-mentor">check details</a>.</p>
+        <div class="govuk-inset-text">
+            If this is not the person you intended to register as a mentor, go back and <a href="find-mentor.html">check details</a>.
+          </div>
     </div>
 </div>
 

--- a/app/views/v3/school/mentor/what-youll-need.html
+++ b/app/views/v3/school/mentor/what-youll-need.html
@@ -23,11 +23,11 @@ href: "javascript:window.history.back()"
 
             <h1 class="govuk-heading-l">{{pageName}}</h1>
 
-            <p>You must provide your mentor's:</p>
+            <p>You must provide the mentor's:</p>
             <ul class="govuk-list govuk-list--bullet">
+                <li>name</li>
                 <li>teacher reference number (TRN)</li>
                 <li>date of birth</li>
-                <li>full name</li>
                 <li>email address</li>
             </ul>
 

--- a/app/views/v3/school/mentor/who-will-be-mentoring.html
+++ b/app/views/v3/school/mentor/who-will-be-mentoring.html
@@ -46,7 +46,7 @@ href: "javascript:window.history.back()"
         },
         {
         value: "Someone else",
-        text: "Add a new mentor"
+        text: "Register a new mentor"
         }
         ]
         }) }}

--- a/app/views/v3/school/review-ect-details.html
+++ b/app/views/v3/school/review-ect-details.html
@@ -117,8 +117,9 @@ href: "javascript:window.history.back()"
             </button>
         </form>
 
-        <p>If this is not the person you intended to register as an ECT, go back and <a href="find-ect">check details</a>.</p>
-    </div>
+       
 </div>
-
+<div class="govuk-inset-text">
+    If this is not the person you intended to register as an ECT, go back and <a href="find-ect">check details</a>.
+  </div>
 {% endblock %}

--- a/app/views/v3/school/start-month.html
+++ b/app/views/v3/school/start-month.html
@@ -6,7 +6,7 @@
 {% set name = 'John Smith' %}
 {% endif %}
 
-{% set pageName="What is that date that " + name + " started at your school?" %}
+{% set pageName="What is the date " + name + " either started or will start as an ECT at your school?" %}
 
 {% block beforeContent %}
 {{ govukBackLink({
@@ -28,7 +28,7 @@ href: "javascript:window.history.back()"
                             {{pageName}}
                         </h1>
                     </legend>
-                    <p>You must tell us the date when {{name}} will begin working at your school.</p>
+                    <p>You must provide the date when {{name}} officially started or is expected to start as an early career teacher at your school.</p>
                     <div id="start-month-hint" class="govuk-hint">
                         For example, 9 2024
                     </div>

--- a/app/views/v3/school/what-youll-need.html
+++ b/app/views/v3/school/what-youll-need.html
@@ -26,7 +26,7 @@ href: "javascript:window.history.back()"
                 <li>date of birth</li>
                 <li>email address</li>
                 <li>start date at your school</li>
-                <li>appropriate body assessing their induction</li>
+                <li>appropriate body (who help assess their induction)</li>
             </ul>
 
 


### PR DESCRIPTION
Changes include:

- Fix the question asking when the ECT starts at the school.
- Look at the content that shows when we ask the mentor for an ECT.
- Check and update content for What you'll need to do next page for ECTs.
- Update statuses on View ECTs page to be slightly more useful - e.g. 'requires mentor' and 'registered' or 'currently training'.
- Look at the content for what you'll need to register an ECT, especially focusing on start date and appropriate body.
- Tweak check details for the ECT page to remove induction start date and check their order.
- Update check your answers page for adding a mentor.
- Update last confirmation page for adding a mentor.